### PR TITLE
[c] Fix Android Gradle Plugin error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Description
 A sample of event bus for Android development with RxJava on Kotlin language.
 
 Status on CircleCI:
-[![Circle CI](https://circleci.com/gh/duchuyctlk/Rx-Kotlin-Sample/tree/dev.svg?style=svg)](https://circleci.com/gh/duchuyctlk/Rx-Kotlin-Sample/tree/dev)
+[![Circle CI](https://circleci.com/gh/duchuyctlk/Rx-Kotlin-Sample/tree/master.svg?style=svg)](https://circleci.com/gh/duchuyctlk/Rx-Kotlin-Sample/tree/master)
 Coverage:
 [![Coverage Status](https://coveralls.io/repos/github/duchuyctlk/Rx-Kotlin-Sample/badge.svg?branch=master)](https://coveralls.io/github/duchuyctlk/Rx-Kotlin-Sample?branch=master)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['connectedCheck', 'test'])
     description = 'Generate Jacoco coverage reports after running tests.'
 
     reports {
-        xml.enabled = false
+        xml.enabled = true
         html.enabled = true
     }
 


### PR DESCRIPTION
- Enable jacoco xml report so coveralls.io can get the coverage.
- Add an environment variable to circleCI to fix the Gradle Plugin error.
- Update badges.
